### PR TITLE
fix: deprecated --no-dev poetry option

### DIFF
--- a/.github/workflows/python_package_build_template.yml
+++ b/.github/workflows/python_package_build_template.yml
@@ -61,7 +61,7 @@ jobs:
         run: timeout 10s poetry run pip --version || rm -rf .venv
 
       - name: Install dependencies
-        run: poetry install --no-dev
+        run: poetry install --without dev
 
       - name: Check imports
         run: poetry run python -c 'from ${{ inputs.package_name }} import __version__; print(__version__)'


### PR DESCRIPTION
```
Creating virtualenv datetime-helpers in /home/runner/work/datetime-helpers/datetime-helpers/.venv
The `--no-dev` option is deprecated, use the `--only main` notation instead.
Installing dependencies from lock file
```